### PR TITLE
Fixes spec_helper.rb by passing missing testing_ui parameter

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,6 @@ end
 
 # A stubbed out Dangerfile for use in tests
 def testing_dangerfile
-  env = Danger::EnvironmentManager.new(testing_env)
+  env = Danger::EnvironmentManager.new(testing_env, testing_ui)
   Danger::Dangerfile.new(env, testing_ui)
 end


### PR DESCRIPTION
'allo. Another huge PR :) This one's marginally more important than just a typo though.

Before this diff, I'd get errors like:

```
$ be rake spec
/usr/local/Cellar/ruby/2.2.2/bin/ruby -I/usr/local/lib/ruby/gems/2.2.0/gems/rspec-core-3.5.4/lib:/usr/local/lib/ruby/gems/2.2.0/gems/rspec-support-3.5.0/lib /usr/local/lib/ruby/gems/2.2.0/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
.F

Failures:

  1) Danger::DangerPlugin with Dangerfile Does something
     Failure/Error: env = Danger::EnvironmentManager.new(testing_env)

     NoMethodError:
       undefined method `title' for nil:NilClass
     # ./spec/spec_helper.rb:57:in `new'
     # ./spec/spec_helper.rb:57:in `testing_dangerfile'
     # ./spec/plugin_spec.rb:11:in `block (3 levels) in <module:Danger>'

Finished in 0.02031 seconds (files took 0.43747 seconds to load)
2 examples, 1 failure
```

And nobody wants that.

But looking at https://github.com/danger/danger/blob/master/spec/spec_helper.rb#L66-L69 gave me the hint that it was an erroneous template.

Now I'm getting all kinds of* green in my shell with tests passing, and it's a happy day.

(*one kind of)