### PR TITLE
Fixing RSpec template

### DIFF
--- a/spec/PLUGIN_spec.rb
+++ b/spec/PLUGIN_spec.rb
@@ -12,7 +12,7 @@ module Danger
     describe 'with Dangerfile' do
       before do
         @dangerfile = testing_dangerfile
-        @my_plugin = @dangerfile.my_plugin
+        @my_plugin = @dangerfile.${PLUGIN_FILE}
       end
 
       # Some examples for writing tests
@@ -39,4 +39,3 @@ module Danger
     end
   end
 end
-


### PR DESCRIPTION
Fixes #11 

## Problem

When template is configured, there is a call to `Dangerfile.my_plugin` which should be replaced by the actual plugin name,

## Solution

Fixed rspec template so that `my_plugin` is replaced with actual plugin method when `./configure` runs