### PR TITLE
Add .yardoc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 pkg
 .idea/
+.yardoc


### PR DESCRIPTION
I added `.yardoc` to `.gitignore`.

When I execute `rake spec`, documentations are generated automatically and `.yardoc` was generated.
It is so noisy, so I ignored it.