### PR TITLE
Don't use vulnerable dependencies

### DIFF
--- a/PLUGIN.gemspec.template
+++ b/PLUGIN.gemspec.template
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.4'
 
   # Linting code and docs
-  spec.add_development_dependency "rubocop", "~> 0.41"
-  spec.add_development_dependency "yard", "~> 0.8"
+  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "yard"
 
   # Makes testing easy via `bundle exec guard`
   spec.add_development_dependency 'guard', '~> 2.14'


### PR DESCRIPTION
GitHub raises Security Vulnerability alert for this version of yard and rubocop.

So, I removed pessimistic versioning operators to unfix versions.