### PR TITLE
Update target ruby version to 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@
 # If you don't like these settings, just delete this file :)
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
     - bundle
 
 rvm:
-  - 2.6
   - 2.7
 
 script:


### PR DESCRIPTION
Danger supports Ruby 2.7 and above from v9.0, so generated plugins should also target 2.7, which is the lower limit.